### PR TITLE
Changed js version in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
         "strictFunctionTypes": true,
         "skipLibCheck": true,
         "lib": [
-            "es5",
+            "es7",
             "dom",
             "es2015.promise",
             "es2015.collection",


### PR DESCRIPTION
Great thanks for the repository! 
When I tried to build the babylon-vrm-loader, I got error messages.

```bash
[tsl] ERROR in /<home>/vrm_loader/babylon-vrm-loader/src/vrm-manager.ts(177,40)
      TS2339: Property 'find' does not exist on type 'AbstractMesh[]'.
[tsl] ERROR in /<home>/vrm_loader/babylon-vrm-loader/src/vrm-manager.ts(177,46)
      TS7006: Parameter 'm' implicitly has an 'any' type.
[tsl] ERROR in /<home>/vrm_loader/babylon-vrm-loader/src/vrm-manager.ts(177,49)
      TS7006: Parameter 'index' implicitly has an 'any' type.
[tsl] ERROR in /<home>/vrm_loader/babylon-vrm-loader/src/vrm-manager.ts(183,23)
      TS2339: Property 'startsWith' does not exist on type 'string'.
[tsl] ERROR in /<home>/vrm_loader/babylon-vrm-loader/src/test/index.ts(107,22)
      TS2339: Property 'includes' does not exist on type 'string'.
[tsl] ERROR in /<home>/vrm_loader/babylon-vrm-loader/src/test/index.ts(108,22)
      TS2339: Property 'includes' does not exist on type 'string'.
```
With the change from "es5 " to "es7" in tsconfig.json, "yarn build" passed.
